### PR TITLE
Feat/header typed data

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,5 +9,5 @@
 	"name": "libstone",
     "targetType": "autodetect",
 	"targetName": "stone",
-	"dflags": ["-preview=dip1000", "-preview=in", "-betterC"]
+	"dflags": ["-preview=dip1000", "-preview=in", "-betterC", "-J=test"]
 }

--- a/source/stone/headers/package.d
+++ b/source/stone/headers/package.d
@@ -90,6 +90,7 @@ public struct AgnosticContainerHeader
 
 package:
     pragma(inline, true) pure @property T data(T)()
+            if (T.sizeof == 24 && __traits(isPOD, T))
     {
         return cast(T) data_;
     }

--- a/source/stone/headers/package.d
+++ b/source/stone/headers/package.d
@@ -27,6 +27,14 @@ public import stone.headers.v1;
  */
 const containerHeader = 0x006d6f73;
 
+/**
+ * Version of the header format
+ */
+public enum HeaderVersion : uint32_t
+{
+    v1 = 1,
+}
+
 /** 
  * The header is initially read as an AgnosticContainerHeader, allowing
  * only two fields to be read: `version` and `magic`
@@ -51,10 +59,10 @@ public struct AgnosticContainerHeader
     /** 
      * Returns: the version identifer as an integer (stored: BE)
      */
-    pragma(inline, true) pure @property uint32_t version_()
+    pragma(inline, true) pure @property HeaderVersion version_()
     {
         ubyte[uint32_t.sizeof] byteSection = rawHeader[$ - uint32_t.sizeof .. $];
-        return bigEndianToNative!(uint32_t, uint32_t.sizeof)(byteSection);
+        return bigEndianToNative!(HeaderVersion, HeaderVersion.sizeof)(byteSection);
     }
 
     /** 
@@ -63,9 +71,9 @@ public struct AgnosticContainerHeader
      * Params:
      *   newVersion = Version to set within the payload
      */
-    pragma(inline, true) pure @property void version_(uint32_t newVersion)
+    pragma(inline, true) pure @property void version_(HeaderVersion newVersion)
     {
-        rawHeader[$ - uint32_t.sizeof .. $] = nativeToBigEndian(newVersion);
+        rawHeader[$ - HeaderVersion.sizeof .. $] = nativeToBigEndian(newVersion);
     }
 
     /** 

--- a/source/stone/headers/package.d
+++ b/source/stone/headers/package.d
@@ -51,18 +51,11 @@ public enum HeaderVersion : uint32_t
 public struct AgnosticContainerHeader
 {
     /** 
-     * Raw data for this header.
-     */
-    ubyte[32] rawHeader;
-    alias rawHeader this;
-
-    /** 
      * Returns: the version identifer as an integer (stored: BE)
      */
     pragma(inline, true) pure @property HeaderVersion version_()
     {
-        ubyte[uint32_t.sizeof] byteSection = rawHeader[$ - uint32_t.sizeof .. $];
-        return bigEndianToNative!(HeaderVersion, HeaderVersion.sizeof)(byteSection);
+        return bigEndianToNative!(HeaderVersion, HeaderVersion.sizeof)(version__);
     }
 
     /** 
@@ -73,7 +66,7 @@ public struct AgnosticContainerHeader
      */
     pragma(inline, true) pure @property void version_(HeaderVersion newVersion)
     {
-        rawHeader[$ - HeaderVersion.sizeof .. $] = nativeToBigEndian(newVersion);
+        version__ = nativeToBigEndian(newVersion);
     }
 
     /** 
@@ -81,8 +74,7 @@ public struct AgnosticContainerHeader
      */
     pragma(inline, true) pure @property uint32_t magic()
     {
-        ubyte[uint32_t.sizeof] byteSection = rawHeader[0 .. uint32_t.sizeof];
-        return bigEndianToNative!(uint32_t, uint32_t.sizeof)(byteSection);
+        return bigEndianToNative!(uint32_t, uint32_t.sizeof)(magic_);
     }
 
     /** 
@@ -93,6 +85,23 @@ public struct AgnosticContainerHeader
      */
     pragma(inline, true) pure @property void magic(uint32_t newMagic)
     {
-        rawHeader[0 .. uint32_t.sizeof] = nativeToBigEndian(newMagic);
+        magic_ = nativeToBigEndian(newMagic);
     }
+
+package:
+    pragma(inline, true) pure @property T data(T)()
+    {
+        return cast(T) data_;
+    }
+
+private:
+    AgnosticContainerHeaderPayload payload;
+    alias payload this;
+}
+
+package struct AgnosticContainerHeaderPayload
+{
+    ubyte[4] magic_;
+    ubyte[24] data_;
+    ubyte[4] version__;
 }

--- a/source/stone/headers/v1.d
+++ b/source/stone/headers/v1.d
@@ -60,7 +60,7 @@ public enum FileType : uint8_t
 public struct StoneContainerHeaderV1
 {
     /** 
-     * 32-byte sequence - interchangeable (lossless) with AgnosticContainerHeader
+     * 32-byte struct - interchangeable (lossless) with AgnosticContainerHeader
      */
     AgnosticContainerHeader hdr;
     alias hdr this;
@@ -70,8 +70,7 @@ public struct StoneContainerHeaderV1
      */
     pragma(inline, true) pure @property uint16_t payloads() @safe @nogc nothrow
     {
-        ubyte[uint16_t.sizeof] rawBytes = hdr[uint32_t.sizeof .. uint32_t.sizeof + uint16_t.sizeof];
-        return bigEndianToNative!(uint16_t, uint16_t.sizeof)(rawBytes);
+        return bigEndianToNative!(uint16_t, uint16_t.sizeof)(data.payloads);
     }
 
     /** 
@@ -79,8 +78,7 @@ public struct StoneContainerHeaderV1
      */
     pragma(inline, true) pure @property ubyte[integrityCheck.length] integrity() @safe @nogc nothrow
     {
-        return hdr[uint32_t.sizeof + uint16_t.sizeof .. uint32_t.sizeof
-            + uint16_t.sizeof + integrityCheck.length];
+        return data.integrity;
     }
 
     /** 
@@ -88,6 +86,19 @@ public struct StoneContainerHeaderV1
      */
     pragma(inline, true) pure @property FileType type() @safe @nogc nothrow
     {
-        return cast(FileType) hdr[$ - (uint32_t.sizeof + FileType.sizeof)];
+        return data.type;
     }
+
+private:
+    pragma(inline, true) pure @property StoneContainerHeaderV1Data data() @safe @nogc nothrow
+    {
+        return hdr.data!StoneContainerHeaderV1Data;
+    }
+}
+
+package struct StoneContainerHeaderV1Data
+{
+    ubyte[uint16_t.sizeof] payloads;
+    ubyte[integrityCheck.length] integrity;
+    FileType type;
 }

--- a/source/stone/headers/v1.d
+++ b/source/stone/headers/v1.d
@@ -22,24 +22,14 @@ import std.bitmanip : bigEndianToNative;
 
 @safe:
 
-@system unittest
+@safe unittest
 {
-    import core.sys.posix.unistd : read, close;
-    import core.sys.posix.fcntl : open, O_RDONLY;
-    import core.stdc.stdio : printf;
-
-    auto fi = open("test/bash-completion-2.11-1-1-x86_64.stone", O_RDONLY);
-    assert(fi > 0);
-    scope (exit)
-        fi.close;
-
-    AgnosticContainerHeader hdr;
-    assert(fi.read(hdr.ptr, hdr.sizeof) == hdr.sizeof);
+    auto hdr = cast(AgnosticContainerHeader) import("bash-completion-2.11-1-1-x86_64.stone");
     assert(hdr.magic == containerHeader);
 
     auto v1Hdr = cast(StoneContainerHeaderV1) hdr;
     assert(v1Hdr.version_ == 1);
-    printf("Headers: %d\n", v1Hdr.payloads);
+    assert(v1Hdr.payloads == 4);
     assert(v1Hdr.integrity == integrityCheck);
     assert(v1Hdr.type == FileType.binary);
 }

--- a/source/stone/headers/v1.d
+++ b/source/stone/headers/v1.d
@@ -17,7 +17,7 @@ module stone.headers.v1;
 
 public import std.stdint : uint8_t, uint16_t, uint32_t;
 
-import stone.headers : AgnosticContainerHeader, containerHeader;
+import stone.headers : AgnosticContainerHeader, HeaderVersion, containerHeader;
 import std.bitmanip : bigEndianToNative;
 
 @safe:
@@ -26,9 +26,9 @@ import std.bitmanip : bigEndianToNative;
 {
     auto hdr = cast(AgnosticContainerHeader) import("bash-completion-2.11-1-1-x86_64.stone");
     assert(hdr.magic == containerHeader);
+    assert(hdr.version_ == HeaderVersion.v1);
 
     auto v1Hdr = cast(StoneContainerHeaderV1) hdr;
-    assert(v1Hdr.version_ == 1);
     assert(v1Hdr.payloads == 4);
     assert(v1Hdr.integrity == integrityCheck);
     assert(v1Hdr.type == FileType.binary);


### PR DESCRIPTION
This PR adds plain old data structs to describe the header payloads to improve the mapping vs a byte array.  `AgnosticContainerHeader` exposes a generic `data` property the versioned headers can use to cast the 24 byte data to it's data representation and requires a 24byte POD type to use. I've left this `package` visibility since only the versioned headers should be using this internally. 

I've also added a typed `HeaderVersion` enum and made the unit test safe by directly importing the test file as the header type.