### PR TITLE
Reader changes

### DIFF
--- a/source/stone/reader/impl.d
+++ b/source/stone/reader/impl.d
@@ -17,6 +17,7 @@ module stone.reader.impl;
 
 import std.range : ElementType, isInputRange, hasLength;
 import stone.headers : AgnosticContainerHeader;
+import stone.reader.mmap : mappedFile, MappedFile;
 public import std.sumtype;
 
 public import stone.headers : containerHeader, HeaderVersion;
@@ -130,31 +131,10 @@ package struct StoneReader(Range)
  * Return a StoneReader for the given input path
  * Note: This is automatically wrapped into an mmap reader
  */
-auto stoneReader(const char* path)
-{
-    import stone.reader.mmap : mappedFile, MappedFile;
-
-    static struct MappedReader
-    {
-        MappedFile mf;
-        StoneReader!(ubyte[]) parent;
-        alias parent this;
-
-        @disable this(this);
-        @disable this();
-
-        this(const char* path) @trusted
-        {
-            this.mf = mappedFile(path);
-            this.data = mf[];
-        }
-    }
-
-    return MappedReader(path);
-}
+StoneReader!MappedFile stoneReader(const char* path) => StoneReader!MappedFile(mappedFile(path));
 
 /**
  * Construct a new StoneReader for the given input range
  * Note: The range must be a ubyte[] slice with a known length.
  */
-auto stoneReader(Range)(Range input) => StoneReader!Range(input);
+StoneReader!Range stoneReader(Range)(Range input) => StoneReader!Range(input);

--- a/source/stone/reader/mmap.d
+++ b/source/stone/reader/mmap.d
@@ -26,8 +26,7 @@ import core.sys.posix.sys.stat;
 @safe unittest
 {
     auto nonExistent = mappedFile("REAMDE.notmd");
-    auto data = nonExistent[0 .. 32];
-    assert(data == null);
+    assert(nonExistent == null);
 
     /* Check README header matches expectations */
     auto doExist = mappedFile("README.md");
@@ -40,37 +39,11 @@ import core.sys.posix.sys.stat;
  */
 public struct MappedFile
 {
+    alias data this;
+    ubyte[] data;
+
     @disable this();
     @disable this(this);
-
-    /** 
-     * Slice the mapped file
-     *
-     * Params:
-     *   start = Start of the requested slice
-     *   end = End of the requested slice
-     * Returns: a ubyte[] slice for the given input
-     */
-    auto opSlice(size_t start, size_t end) @nogc nothrow
-    {
-        if (start > end || end > fileSize || fileSize == 0)
-            return null;
-
-        return () @trusted { return cast(ubyte[])(dataPage[start .. end]); }();
-    }
-
-    ubyte[] opSlice() @nogc nothrow
-    {
-        if (fileSize == 0)
-            return null;
-        return () @trusted { return cast(ubyte[])(dataPage[0 .. fileSize]); }();
-    }
-
-    /** 
-     * Returns: Length of the mapped file
-     */
-    auto opDollar() @nogc nothrow => fileSize;
-    alias length = opDollar;
 
     ~this() @trusted nothrow @nogc
     {
@@ -101,6 +74,8 @@ private:
         dataPage = mmap(null, result.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
         if (dataPage is null)
             return;
+
+        data = cast(ubyte[])(dataPage[0 .. fileSize]);
     }
 
     /* Underlying file descriptor */


### PR DESCRIPTION
Remove `header` from `StoneReader` since it doesn't need to be stored here and only passed down into the versioned reader. 

I've also tried making the `MappedFile` itself a `Range` by aliasing itself as the byte range it references. This allows us to use it as the generic for `StoneReader!MappedFile` instead of returning an opaque type that wraps the reader and aliases to it.